### PR TITLE
Plaintextmail

### DIFF
--- a/inc/lang/en_en.php
+++ b/inc/lang/en_en.php
@@ -198,4 +198,13 @@ $GLOBALS['lang'] = array(
 '9' => 'nine',
 'derniere_connexion_le' => 'Last connection from',
 'cet_ordi' => 'this computer',
+// Formulaire mail
+'mail_subject' => 'New comment on "',
+'mail_message1' => 'A new comment by ',
+'mail_message2' => ' has been posted on ',
+'mail_message3' => ' from ',
+'mail_link' => 'You can see it by following this link: ',
+'mail_unsub' => 'To unsubscribe from the comments on that post, you can follow this link: ',
+'mail_unsuball' => 'To unsubscribe from the comments on all the posts, follow this link: ',
+'mail_end' => 'Also, do not reply to this email, since it is an automatic generated email.\nRegards',
 );

--- a/inc/lang/fr_fr.php
+++ b/inc/lang/fr_fr.php
@@ -198,4 +198,13 @@ $GLOBALS['lang'] = array(
 '9' => 'neuf',
 'derniere_connexion_le' => 'Dernière connexion depuis',
 'cet_ordi' => 'cet ordinateur',
+'mail_subject' => 'Nouveau commentaire sur "',
+'mail_message1' => 'Un nouveau commentaire par ',
+'mail_message2' => ' a été posté sur le sujet ',
+'mail_message3' => ' depuis ',
+'mail_link' => 'Vous pouvez le consulter via ce lien: ',
+'mail_unsub' => 'Pour vous désinscrire des commentaires de ce billet, suivez ce lien: ',
+'mail_unsuball' => 'Pour vous désinscrire des commentaires de tous les billets, suivez ce lien: ',
+'mail_end' => 'Merci de ne pas répondre à ce message automatique.',
+
 );

--- a/inc/util.php
+++ b/inc/util.php
@@ -424,21 +424,22 @@ function send_emails($id_comment)
         return true;
     }
 
-    $subject = 'New comment on "'.$article_title.'" - '.$GLOBALS['nom_du_site'];
+    $subject = $GLOBALS['lang']['mail_subject'].$article_title.'" - '.$GLOBALS['nom_du_site'];
     $headers  = 'MIME-Version: 1.0'."\r\n".'Content-type: text/html; charset="UTF-8"'."\r\n";
     $headers .= 'From: no.reply_'.$GLOBALS['email']."\r\n".'X-Mailer: BlogoText - PHP/'.phpversion();
 
     // send emails
     foreach ($to_send_mail as $mail) {
         $unsublink = get_blogpath($article_id, '').'&amp;unsub=1&amp;mail='.base64_encode($mail).'&amp;article='.$article_id;
-        $message = '<html>';
-        $message .= '<head><title>'.$subject.'</title></head>';
-        $message .= '<body><p>A new comment by <b>'.$comm_author.'</b> has been posted on <b>'.$article_title.'</b> form '.$GLOBALS['nom_du_site'].'.<br/>';
-        $message .= 'You can see it by following <a href="'.get_blogpath($article_id, '').'#'.article_anchor($id_comment).'">this link</a>.</p>';
-        $message .= '<p>To unsubscribe from the comments on that post, you can follow this link:<br/><a href="'.$unsublink.'">'.$unsublink.'</a>.</p>';
-        $message .= '<p>To unsubscribe from the comments on all the posts, follow this link:<br/> <a href="'.$unsublink.'&amp;all=1">'.$unsublink.'&amp;all=1</a>.</p>';
-        $message .= '<p>Also, do not reply to this email, since it is an automatic generated email.</p><p>Regards</p></body>';
-        $message .= '</html>';
+        $message = $subject."\r\n";
+        $message .= str_repeat('=', strlen($subject)) ."\r\n\n";
+        $message .= $GLOBALS['lang']['mail_message1'].$comm_author.$GLOBALS['lang']['mail_message2'].$article_title.$GLOBALS['lang']['mail_message3'].$GLOBALS['nom_du_site']."\r\n";
+        $message .= $GLOBALS['lang']['mail_link'].get_blogpath($article_id, '').'#'.article_anchor($id_comment)."\r\n\n";
+        $message .= "---\r\n\n";
+        $message .= $GLOBALS['lang']['mail_unsub']."\r\n".$unsublink.'">'.$unsublink."\r\n\n";
+        $message .= $GLOBALS['lang']['mail_unsuball']."\r\n".$unsublink.'&amp;all=1">'.$unsublink.'&amp;all=1'."\r\n";
+        $message .= "\r\n";
+        $message .= $GLOBALS['lang']['mail_end'];
         mail($mail, $subject, $message, $headers);
     }
     return true;


### PR DESCRIPTION
Les mails en html, c'est pénible et ça ne sert bien souvent à rien.
Ce commit propose un mail en plaintext, avec au passage une traduction selon la langue du site.