### PR TITLE
Space after "Up to" missing in inc/lang/en

### DIFF
--- a/inc/lang/en_en.php
+++ b/inc/lang/en_en.php
@@ -151,7 +151,7 @@ $LANG = array(
 // placeholders
 'placeholder_search' => 'Search',
 //Formulaire Images
-'label_upto' => 'Up to',
+'label_upto' => 'Up to ',
 'label_perfile' => ' per file',
 'label_codes' => 'Integration codes:',
 // Chiffres 0 à 9 pour captcha


### PR DESCRIPTION
To patch this: 
![chrome_2017-10-11_11-58-14](https://user-images.githubusercontent.com/12259540/31434024-7c9975a2-ae7b-11e7-800f-7e7223775d43.png)
